### PR TITLE
Triton logs metrics to Neptune during live berbalang runs now.

### DIFF
--- a/neptune/berb_watcher.py
+++ b/neptune/berb_watcher.py
@@ -1,0 +1,63 @@
+import neptune,triton
+import toml
+import os,sys
+import numpy as np
+import simplejson as json
+import time
+import tailer
+from watchdog.observers import Observer
+from watchdog.events import PatternMatchingEventHandler
+
+write_count=0
+current_epoch=0
+island="island_0"
+
+def on_created(event):
+   if event.is_directory:
+   #config-0 at the top-level of a log tree indicates an experiment
+   #has started to run. Call build_experiment to create it in neptune
+      if event.src_path.endswith("config-0"):
+         print(f"{event.src_path} has been created")
+         session_config_path = event.src_path+"/config.toml"
+         triton.read_toml(session_config_path)
+         triton.build_experiment()
+
+def on_modified(event):
+   if event.src_path.endswith(".csv") and island in event.src_path:
+      print(f"{event.src_path} has been modified")
+      logpath=event.src_path
+      #for w in watchlist:
+      #   if w in logpath:
+      if "mean" in logpath:
+            logline=tailer.tail(open(logpath),1)[0]
+            stats=[float(l) for l in logline.strip().split(",")]
+            triton.log_stats_to_experiment(stats,logpath)
+
+if __name__ == "__main__":
+    # create the event handler
+    patterns="*.csv"
+    ignore_patterns = ["^./.git"]
+    ignore_directories = False
+    case_sensitive = True
+#    my_event_handler = RegexMatchingEventHandler(ignore_regexes=ignore_patterns, ignore_directories=ignore_directories, case_sensitive=case_sensitive)
+    my_event_handler = PatternMatchingEventHandler(patterns, ignore_patterns, ignore_directories, case_sensitive)
+
+    my_event_handler.on_created = on_created
+    my_event_handler.on_modified = on_modified
+
+    # create an observer
+    path = "/home/armadilo/logs/berbalang/Roper/Tournament"
+    go_recursively = True
+    my_observer = Observer()
+    my_observer.schedule(my_event_handler, path, recursive=go_recursively)
+
+    triton = triton.Triton(path,0,"special-circumstances","sandbox")
+
+    my_observer.start()
+    try:
+        while True:
+            time.sleep(5)
+    except:
+        my_observer.stop()
+        print("Observer Stopped")
+    my_observer.join()

--- a/neptune/triton.py
+++ b/neptune/triton.py
@@ -5,86 +5,72 @@ import numpy as np
 import simplejson as json
 import time
 import tailer
-import subprocess
-from watchdog.observers import Observer
-from watchdog.events import PatternMatchingEventHandler
+import neptune
 
 class Triton:
 
-   def __init__(self,watch_path,island):
+   def __init__(self,watch_path,island,namespace,proj_name):
 
        self.session_config_path = ""
        self.config_toml=""
        self.log_path = watch_path
        self.island_num=island
        self.exp_params={}
-       self.exp_project_path="special-circumstances/sandbox"
+       self.exp_pqn=namespace+"/"+proj_name
+       self.experiment=""
+       self.watchlist=["best","mean","champion"]
 
-   def read_toml(path):
+   
+   def read_toml(self,path):
 
       self.config_toml = toml.load(path)
 
-   def read_berb_log(path):
+   def read_berb_log(self,path):
 
       with open(path) as log:
          jl=json.load(log)
       return jl
 
-   #def build_experiment(conf,logpath,resultname):
-    def build_experiment(conf,resultname):
-      exp_config = self.config_toml
+   def build_experiment(self):
+      _exp_config = self.config_toml
       exp_number=1
       #This is a bit messy, but more literal
-      exp_params={'num_islands':exp_config['num_islands'],'mutation_rate':exp_config['mutation_rate'],
-                  'mutation_exponent':exp_config['mutation_exponent'],
-                  'crossover_period':exp_config['crossover_period'],
-                  'crossover_rate':exp_config['crossover_rate'],
-                  'max_init_len':exp_config['max_init_len'],
-                  'min_init_len':exp_config['min_init_len'],
-                  'pop_size':exp_config['pop_size'],
-                  'max_length':exp_config['max_length']
+      _exp_params={'num_islands': _exp_config['num_islands'],'mutation_rate': _exp_config['mutation_rate'],
+                  'mutation_exponent': _exp_config['mutation_exponent'],
+                  'crossover_period': _exp_config['crossover_period'],
+                  'crossover_rate': _exp_config['crossover_rate'],
+                  'max_init_len': _exp_config['max_init_len'],
+                  'min_init_len': _exp_config['min_init_len'],
+                  'pop_size': _exp_config['pop_size'],
+                  'max_length': _exp_config['max_length']
                   }
-      }
 
-      #champ = read_berb_log(self.log_path)
-      #exp_name=champ['chromosome']['name']
-      #exp_desc=str(champ['tag'])
-      exp_name=exp_config['population_name']
-      exp_properties={"data_version":exp_config['population_name'],"data_path":"/home/armadilo/projects/berbalang/agaricus-lepiota.tsv"}
-      exp_tags=["sometag","some_other_tag"]
-      exp_source="./trials.sh"
-      }
-      with open(resultname,'w') as log_f:
-          json.dump(experiment,log_f)
+      #_exp_name=_exp_config['population_name']
+      _exp_name="scute-halux-orbit-naris"
 
-   def on_created(event):
-       print(f"{event.src_path}" has been created")
-       if event.is_directory:
-       #print(f"{event.src_path} has been created")
-          #if "island" in event.src_path:
-            # print(f"{event.src_path} has been created")
+      neptune.init(self.exp_pqn,api_token=None) 
+      self.experiment=neptune.create_experiment(name=_exp_name,params=_exp_params)
+      print(f" Created experiment {_exp_name} in {self.exp_pqn}")
+      
+   def get_session(self):
+ 
+      return Session.with_default_backend(api_token=None)
 
-        #config-0 at the top-level of a log tree indicates an experiment
-        #has started to run. Call build_experiment to create it in neptune
-          if "config-0" in event.src_path:
-             self.session_config_path = event.src_path+"/config.toml"
-             self.read_toml(self.session_config_path)
-             self.build_experiment()
-             build_experiment("/home/armadilo/projects/berbalang/config.toml","home/armadilo/projects/berbalang/neptune/experiment.json")
+   def get_experiment(self):
 
-          #If a csv file is created in the island dir
-          #Spin up a tailf subprocess
-          if event.src_path.endswith(".csv"):
-              self.tailer(event.src_path,self.)
+      return self.experiment 
 
+   def get_experiment_context(self): 
+       
+       _session = Session.with_default_backend(api_token=None)
+       _project = _session.get_project(self.exp_pqn)
+       _exp = _project.get_experiments(id=self.exp_name)[0]
 
-       else:
-          if ".json" in event.src_path:
-             print(f"Found pre-compressed json file: {event.src_path} ")
-
-   def on_modified(event):
-       print(f"{event.src_path} has been modified")
-
-   if __name__ == "__main__":
-
-       build_experiment("/home/armadilo/projects/berbalang/config.toml","/home/armadilo/logs/berbalang/Roper/Tournament/2020/08/26/config-0/island_0/champions/champion_12288.json","./experiment.json")
+       return tuple(_session,_project,_exp)
+ 
+   def log_stats_to_experiment(self,stats,path):
+  
+      for s in range(0,len(stats)):
+         metric_num=str(s)
+         metric_name=str("metric_"+metric_num)
+         self.experiment.log_metric(metric_name,stats[s])   


### PR DESCRIPTION
This is still pretty hacky, but its functional and is a good stake to put in the ground. 
Rewrote a good bit of Triton to serve as an interface object into Neptune.
Next stop: Look into replacing current parsing with something like Pandas. 