### PR TITLE
no longer committing on interrupts

### DIFF
--- a/src/emulator/hatchery.rs
+++ b/src/emulator/hatchery.rs
@@ -693,7 +693,8 @@ pub mod hooking {
                 // it would be cool if we could save the context at each ret, so that we can rewind
                 // bad gadgets.
                 } else if is_syscall(arch, mode, &inst) {
-                    commit_logs!(engine, registers_to_read => register_state, write_log => committed_write_log, block_log => committed_trace_log);
+                    // Committing the logs at a syscall is one way to get trapped in a non-composable local optima.
+                    // commit_logs!(engine, registers_to_read => register_state, write_log => committed_write_log, block_log => committed_trace_log);
                     engine.emu_stop().expect("Failed to stop emulator");
                 } else {
                     // if not a RETURN

--- a/src/emulator/register_pattern.rs
+++ b/src/emulator/register_pattern.rs
@@ -226,6 +226,12 @@ fn weighted_ham(x: u64, y: u64) -> f64 {
     // weighted hamming distance: the more significant bits
     // cost more
     fn weight(i: usize) -> f64 {
+        // alternately:
+        // TODO
+        // to make least significant bits worth more
+        // let d = i as f64 + 1.0;
+        // 8.0 / d
+
         i as f64 + 1.0
     }
     let mut z = x ^ y;


### PR DESCRIPTION
committing on interrupts makes sense if a final solution to the problem has been reached, but otherwise -- in the vast majority of instances -- is just a way to bait the population into local optima. 